### PR TITLE
Update Detwinner runtime to 46

### DIFF
--- a/com.neatdecisions.Detwinner.json
+++ b/com.neatdecisions.Detwinner.json
@@ -61,8 +61,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.40/GraphicsMagick-1.3.40.tar.gz",
-          "sha256":"88ddbf76e1ced2ab6bcd743207ee308865de1afb4b645d460924dcc8bfc0ee85"
+          "url": "https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.43/GraphicsMagick-1.3.43.tar.xz",
+          "sha256":"2b88580732cd7e409d9e22c6116238bef4ae06fcda11451bf33d259f9cbf399f"
         }
       ]
     },
@@ -72,8 +72,8 @@
       "sources" : [
         {
           "type" : "archive",
-          "url" : "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.5.tar.xz",
-          "sha256" : "705c6d29f4116a29bde4e36cfc1b046c92b6ef8c6dae4eaec85018747e6da5aa"
+          "url" : "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz",
+          "sha256" : "b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7"
         }
       ]
     },
@@ -142,8 +142,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://ftp.acc.umu.se/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.7.tar.xz",
-          "sha256":"1d7a35af9c5ceccacb244ee3c2deb9b245720d8510ac5c7e6f4b6f9947e6789c"
+          "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.9.tar.xz",
+          "sha256":"30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce"
         }
       ]
     },
@@ -153,8 +153,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz",
-          "sha256": "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363"
+          "url": "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz",
+          "sha256": "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7"
         }
       ]
     },

--- a/com.neatdecisions.Detwinner.json
+++ b/com.neatdecisions.Detwinner.json
@@ -9,10 +9,8 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--filesystem=host",
-    "--filesystem=xdg-config/gtk-3.0",
     "--filesystem=xdg-run/gvfsd",
-    "--talk-name=org.gtk.vfs.*",
-    "--talk-name=org.freedesktop.portal.Trash"
+    "--talk-name=org.gtk.vfs.*"
   ],
   "cleanup": [
     "/bin/gm",
@@ -172,3 +170,4 @@
     }
   ]
 }
+

--- a/com.neatdecisions.Detwinner.json
+++ b/com.neatdecisions.Detwinner.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.neatdecisions.Detwinner",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "detwinner",
   "finish-args": [


### PR DESCRIPTION
- Update Detwinner runtime to 46 since runtime version 44 has reached end-of-life.
- Update GraphsMagick from 1.3.40 to 1.3.43
- Update mm-common from 1.0.5 to 1.0.6
- Update gtkmm from 3.24.7 to 3.24.9
- Update gtest from 1.13.0 to 1.14.0