### PR TITLE
Remove mm-common

### DIFF
--- a/com.neatdecisions.Detwinner.json
+++ b/com.neatdecisions.Detwinner.json
@@ -65,17 +65,6 @@
       ]
     },
     {
-      "name" : "mm-common",
-      "buildsystem": "meson",
-      "sources" : [
-        {
-          "type" : "archive",
-          "url" : "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.6.tar.xz",
-          "sha256" : "b55c46037dbcdabc5cee3b389ea11cc3910adb68ebe883e9477847aa660862e7"
-        }
-      ]
-    },
-    {
       "name": "sigc++",
       "buildsystem": "meson",
       "config-opts": [
@@ -84,7 +73,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz",
+          "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc%2B%2B-2.10.8.tar.xz",
           "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"
         }
       ]

--- a/com.neatdecisions.Detwinner.json
+++ b/com.neatdecisions.Detwinner.json
@@ -154,6 +154,10 @@
           "type": "archive",
           "url": "https://github.com/neatdecisions/detwinner/archive/refs/tags/v0.4.2.tar.gz",
           "sha256": "a14928a9bcaf006fb05639978c0acc53011fbcef4552a699c61485b07b0d69bb"
+        },
+        {
+          "type": "patch",
+          "path": "fix-appdata.patch"
         }
       ]
     }

--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,36 @@
+From de5a22692bb4eb728d094d2fe8e16ab8ed4bde23 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 8 Feb 2026 01:09:07 +0300
+Subject: [PATCH] Fix appdata paper cuts
+
+---
+ data/com.neatdecisions.Detwinner.appdata.xml.in | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/data/com.neatdecisions.Detwinner.appdata.xml.in b/data/com.neatdecisions.Detwinner.appdata.xml.in
+index 00a41f6..90b5c31 100644
+--- a/data/com.neatdecisions.Detwinner.appdata.xml.in
++++ b/data/com.neatdecisions.Detwinner.appdata.xml.in
+@@ -19,16 +19,17 @@
+   <launchable type="desktop-id">com.neatdecisions.Detwinner.desktop</launchable>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://neatdecisions.com/images/detwinner-linux/screen01.png</image>
++      <image>https://neatdecisions.com/images/detwinner-linux/screenshots/screen01.png</image>
+     </screenshot>
+     <screenshot>
+-      <image>https://neatdecisions.com/images/detwinner-linux/screen02.png</image>
++      <image>https://neatdecisions.com/images/detwinner-linux/screenshots/screen02.png</image>
+     </screenshot>
+   </screenshots>
+   <url type="homepage">https://neatdecisions.com/products/detwinner-linux/</url>
+   <url type="bugtracker">https://github.com/neatdecisions/detwinner/issues</url>
+   <url type="donation">https://neatdecisions.com/products/detwinner-linux/donate.php</url>
+   <url type="translate">https://poeditor.com/join/project/WvJERjmf1r</url>
++  <url type="vcs-browser">https://github.com/neatdecisions/detwinner</url>
+   <update_contact>opensource@neatdecisions.com</update_contact>
+   ​<translation type="gettext">com.neatdecisions.Detwinner</translation>
+   <provides>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80